### PR TITLE
Fix for Issue pumamood#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tested with Heatmiser Wifi accessory here, not with Netmonitor.
 
 # Installing Plugin
 
-Plugin is NodeJS module published through NPM 
+Plugin is NodeJS module published through NPM
 
 You can install this plugin the same way you installed Homebridge - as a global NPM module. For example:
 
@@ -25,6 +25,8 @@ Add to config.json under "accessories" array
       "accessory": "HeatmiserWifi",
       "ip_address": "your_netmonitor_ip",
       "pin": your_pin,
+      "port": 8086,
+      "model": "your_model",
       "name": "Kitchen Thermostat",
       "room": "Kitchen"
     }
@@ -37,7 +39,7 @@ Add to config.json under "accessories" array
       "ip_address": "your_netmonitor_ip",
       "pin": your_pin,
       "network_address": 1, // Network Address of the Stat you want to talk to
-      "name": "Kitchen Thermostat", 
+      "name": "Kitchen Thermostat",
       "room": "Kitchen"
     }
 ```

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ You can install this plugin the same way you installed Homebridge - as a global 
 
 Add to config.json under "accessories" array
 * For Heatmiser WiFi thermostats
+Options for "your_model" are: "DT", "DT-E", "PRT", "PRT-E", "PRTHW" (see https://github.com/carlossg/heatmiser-node/blob/master/lib/wifi.js#L40)
 ```json
     {
       "accessory": "HeatmiserWifi",
-      "ip_address": "your_netmonitor_ip",
+      "ip_address": "your_heatmiserwifi_ip",
       "pin": your_pin,
       "port": 8086,
       "model": "your_model",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ You can install this plugin the same way you installed Homebridge - as a global 
 
 Add to config.json under "accessories" array
 * For Heatmiser WiFi thermostats
+
 Options for "your_model" are: "DT", "DT-E", "PRT", "PRT-E", "PRTHW" (see https://github.com/carlossg/heatmiser-node/blob/master/lib/wifi.js#L40)
+
 ```json
     {
       "accessory": "HeatmiserWifi",

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function HeatmiserWifi(log, config, api) {
     this.log = log;
     this.ip_address = config["ip_address"];
     this.pin = config["pin"];
+    this.port = config["port"];
+    this.model = config["model"];
     this.lock = new AsyncLock({ timeout: config["timeout"] || 5000 });}
 
 HeatmiserWifi.prototype = {
@@ -30,14 +32,14 @@ HeatmiserWifi.prototype = {
 
     getCurrentHeatingCoolingState: function (callback) {
         this.lock.acquire(key, function (done) {
-            // async work   
+            // async work
             this.log("getCurrentHeatingCoolingState");
 
             //Characteristic.CurrentHeatingCoolingState.OFF = 0;
             //Characteristic.CurrentHeatingCoolingState.HEAT = 1;
             //Characteristic.CurrentHeatingCoolingState.COOL = 2;
             var e = null;
-            var hm = new heatmiser.Wifi(this.ip_address, this.pin);
+            var hm = new heatmiser.Wifi(this.ip_address, this.pin, this.port, this.model);
             hm.on('error', (err) => {
                 this.log('An error occurred! ' + err.message);
                 e = err;
@@ -69,7 +71,7 @@ HeatmiserWifi.prototype = {
         this.lock.acquire(key, function (done) {
             this.log("getTargetHeatingCoolingState");
             var e = null;
-            var hm = new heatmiser.Wifi(this.ip_address, this.pin);
+            var hm = new heatmiser.Wifi(this.ip_address, this.pin, this.port, this.model);
             hm.on('error', (err) => {
                 this.log('An error occurred! ' + err.message);
                 e = err;
@@ -97,7 +99,7 @@ HeatmiserWifi.prototype = {
             this.log("getCurrentTemperature");
 
             var e = null;
-            var hm = new heatmiser.Wifi(this.ip_address, this.pin);
+            var hm = new heatmiser.Wifi(this.ip_address, this.pin, this.port, this.model);
             hm.on('error', (err) => {
                 this.log('An error occurred! ' + err.message);
                 e = err;
@@ -119,7 +121,7 @@ HeatmiserWifi.prototype = {
             this.log("getTargetTemperature");
 
             var e = null;
-            var hm = new heatmiser.Wifi(this.ip_address, this.pin);
+            var hm = new heatmiser.Wifi(this.ip_address, this.pin, this.port, this.model);
             hm.on('error', (err) => {
                 this.log('An error occurred! ' + err.message);
                 e = err;
@@ -144,7 +146,7 @@ HeatmiserWifi.prototype = {
             }
 
             var e = null;
-            var hm = new heatmiser.Wifi(this.ip_address, this.pin);
+            var hm = new heatmiser.Wifi(this.ip_address, this.pin, this.port, this.model);
             hm.on('error', (err) => {
                 this.log('An error occurred! ' + err.message);
                 e = err;
@@ -159,7 +161,7 @@ HeatmiserWifi.prototype = {
             this.log("getTemperatureDisplayUnits");
 
             var e = null;
-            var hm = new heatmiser.Wifi(this.ip_address, this.pin);
+            var hm = new heatmiser.Wifi(this.ip_address, this.pin, this.port, this.model);
             hm.on('error', (err) => {
                 this.log('An error occurred! ' + err.message);
                 e = err;


### PR DESCRIPTION
Error when setting temperature on PRTHW-TS WiFi RF (on Heatmiser WiFi thermostats)

It now needs additional lines in config.json:

Options for "your_model" are: "DT", "DT-E", "PRT", "PRT-E", "PRTHW" (see https://github.com/carlossg/heatmiser-node/blob/master/lib/wifi.js#L40)

    {
      "accessory": "HeatmiserWifi",
      "ip_address": "your_heatmiserwifi_ip",
      "pin": your_pin,
      "port": 8086,
      "model": "your_model",
      "name": "Kitchen Thermostat",
      "room": "Kitchen"
    }
