### PR TITLE
Fix half degree issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Add to config.json under "accessories" array
 
 Options for "your_model" are: "DT", "DT-E", "PRT", "PRT-E", "PRTHW" (see https://github.com/carlossg/heatmiser-node/blob/master/lib/wifi.js#L40)
 
+The mintemp & maxtemp options set the range on the thermostat faceplate. The target temperature step size is now 1 degree as required by Heatmiser
+
 ```json
     {
       "accessory": "HeatmiserWifi",
@@ -30,8 +32,10 @@ Options for "your_model" are: "DT", "DT-E", "PRT", "PRT-E", "PRTHW" (see https:/
       "pin": your_pin,
       "port": 8068,
       "model": "your_model",
-      "name": "Kitchen Thermostat",
-      "room": "Kitchen"
+      "mintemp": 10,
+      "maxtemp": 30,
+      "name": "Thermostat",
+      "room": "Hall"
     }
 ```
 

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ HeatmiserWifi.prototype = {
 
     setTargetTemperature: function (targetTemperature, callback) {
         this.lock.acquire(key, function (done) {
+            targetTemperature=Math.round(targetTemperature);
             this.log("setTargetTemperature " + targetTemperature);
             //this.log(targetTemperature);
             var dcb1 = {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function HeatmiserWifi(log, config, api) {
     this.pin = config["pin"];
     this.port = config["port"];
     this.model = config["model"];
+    this.mintemp = config["mintemp"];
+    this.maxtemp = config["maxtemp"];
     this.lock = new AsyncLock({ timeout: config["timeout"] || 5000 });}
 
 HeatmiserWifi.prototype = {
@@ -137,7 +139,6 @@ HeatmiserWifi.prototype = {
 
     setTargetTemperature: function (targetTemperature, callback) {
         this.lock.acquire(key, function (done) {
-            targetTemperature=Math.round(targetTemperature);
             this.log("setTargetTemperature " + targetTemperature);
             //this.log(targetTemperature);
             var dcb1 = {
@@ -213,6 +214,7 @@ HeatmiserWifi.prototype = {
 
         thermostatService.getCharacteristic(Characteristic.TargetTemperature).on('set', this.setTargetTemperature.bind(this));
         thermostatService.getCharacteristic(Characteristic.TargetTemperature).on('get', this.getTargetTemperature.bind(this));
+        thermostatService.getCharacteristic(Characteristic.TargetTemperature).setProps({minValue: this.mintemp, maxValue: this.maxtemp, minStep: 1});
 
         thermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits).on('set', this.setTemperatureDisplayUnits.bind(this));
         thermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits).on('get', this.getTemperatureDisplayUnits.bind(this));


### PR DESCRIPTION
The Heatmiser doesn't like fractions of degrees for its target temperature. This fixes it by changing the target temperature step size to 1 degree as required by Heatmiser. Also adds mintemp & maxtemp options to set the range on the thermostat faceplate.